### PR TITLE
Decouple framework loading from the CLI by adding error handling

### DIFF
--- a/Sources/Xcproj+LoadFrameworks.h
+++ b/Sources/Xcproj+LoadFrameworks.h
@@ -19,6 +19,8 @@ extern NSString *XcprojErrorDomain;
 typedef NS_ENUM(NSInteger, XcprojError) {
 	XcprojErrorXcodeBundleNotFound = 1,
 	XcprojErrorFrameworksNotLoaded = 2,
+	XcprojErrorIDEInitializeNotFound = 3,
+	XcprojErrorXCInitializeCoreIfNeededNotFound = 4,
 };
 
 @interface Xcproj (LoadFrameworks)

--- a/Sources/Xcproj+LoadFrameworks.h
+++ b/Sources/Xcproj+LoadFrameworks.h
@@ -18,6 +18,7 @@ extern NSString *XcprojErrorDomain;
 
 typedef NS_ENUM(NSInteger, XcprojError) {
 	XcprojErrorXcodeBundleNotFound = 1,
+	XcprojErrorFrameworksNotLoaded = 2,
 };
 
 @interface Xcproj (LoadFrameworks)

--- a/Sources/Xcproj+LoadFrameworks.h
+++ b/Sources/Xcproj+LoadFrameworks.h
@@ -15,12 +15,14 @@ extern Class XCBuildConfiguration;
 extern Class IDEBuildParameters;
 
 extern NSString *XcprojErrorDomain;
+extern NSString *XcprojClassLoadErrorsKey;
 
 typedef NS_ENUM(NSInteger, XcprojError) {
 	XcprojErrorXcodeBundleNotFound = 1,
 	XcprojErrorFrameworksNotLoaded = 2,
 	XcprojErrorIDEInitializeNotFound = 3,
 	XcprojErrorXCInitializeCoreIfNeededNotFound = 4,
+	XcprojErrorClassLoadingFailed = 5,
 };
 
 @interface Xcproj (LoadFrameworks)

--- a/Sources/Xcproj+LoadFrameworks.h
+++ b/Sources/Xcproj+LoadFrameworks.h
@@ -14,8 +14,14 @@ extern Class PBXReference;
 extern Class XCBuildConfiguration;
 extern Class IDEBuildParameters;
 
+extern NSString *XcprojErrorDomain;
+
+typedef NS_ENUM(NSInteger, XcprojError) {
+	XcprojErrorXcodeBundleNotFound = 1,
+};
+
 @interface Xcproj (LoadFrameworks)
 
-+ (void) loadFrameworks;
++ (BOOL) loadFrameworks:(NSError **)error;
 
 @end

--- a/Sources/Xcproj+LoadFrameworks.h
+++ b/Sources/Xcproj+LoadFrameworks.h
@@ -1,0 +1,21 @@
+//
+//  XcodeFrameworkLoader.h
+//  xcproj
+//
+//  Created by Adam Sharp on 19/02/2016.
+//  Copyright © 2016 Cédric Luthi. All rights reserved.
+//
+
+#import "Xcproj.h"
+
+extern Class PBXGroup;
+extern Class PBXProject;
+extern Class PBXReference;
+extern Class XCBuildConfiguration;
+extern Class IDEBuildParameters;
+
+@interface Xcproj (LoadFrameworks)
+
++ (void) loadFrameworks;
+
+@end

--- a/Sources/Xcproj+LoadFrameworks.m
+++ b/Sources/Xcproj+LoadFrameworks.m
@@ -1,0 +1,219 @@
+//
+//  XcodeFrameworkLoader.m
+//  xcproj
+//
+//  Created by Adam Sharp on 19/02/2016.
+//  Copyright © 2016 Cédric Luthi. All rights reserved.
+//
+
+#import "Xcproj+LoadFrameworks.h"
+
+#import <dlfcn.h>
+#import <objc/runtime.h>
+#import "DDCommandLineInterface.h"
+#import "XCDUndocumentedChecker.h"
+#import "XMLPlistDecoder.h"
+
+static NSString *XcodeBundleIdentifier = @"com.apple.dt.Xcode";
+
+static NSBundle * XcodeBundleAtPath(NSString *path)
+{
+	NSBundle *xcodeBundle = [NSBundle bundleWithPath:path];
+	return [xcodeBundle.bundleIdentifier isEqualToString:XcodeBundleIdentifier] ? xcodeBundle : nil;
+}
+
+static NSBundle * XcodeBundle(void)
+{
+	NSString *xcodeAppPath = NSProcessInfo.processInfo.environment[@"XCPROJ_XCODE_APP_PATH"];
+	NSBundle *xcodeBundle = XcodeBundleAtPath(xcodeAppPath);
+	if (!xcodeBundle)
+	{
+		NSTask *task = [NSTask new];
+		task.launchPath = @"/usr/bin/xcode-select";
+		task.arguments = @[@"--print-path"];
+		task.standardOutput = [NSPipe new];
+
+		[task launch];
+		[task waitUntilExit];
+
+		if (task.terminationStatus == 0)
+		{
+			NSData *outputData = [[task.standardOutput fileHandleForReading] readDataToEndOfFile];
+			NSString *outputString = [[NSString alloc] initWithData:outputData encoding:NSUTF8StringEncoding];
+			NSString *xcodePath = [[outputString stringByDeletingLastPathComponent] stringByDeletingLastPathComponent];
+			xcodeBundle = XcodeBundleAtPath(xcodePath);
+		}
+	}
+
+	if (!xcodeBundle)
+	{
+		NSURL *xcodeURL = [[NSWorkspace sharedWorkspace] URLForApplicationWithBundleIdentifier:XcodeBundleIdentifier];
+		xcodeBundle = XcodeBundleAtPath(xcodeURL.path);
+	}
+	
+	if (!xcodeBundle)
+	{
+		ddfprintf(stderr, @"Xcode.app not found.\n");
+		exit(EX_CONFIG);
+	}
+	
+	if (xcodeAppPath && ![[xcodeAppPath stringByResolvingSymlinksInPath] isEqualToString:xcodeBundle.bundlePath])
+	{
+		ddfprintf(stderr, @"WARNING: '%@' does not point to an Xcode app, using '%@'\n", xcodeAppPath, xcodeBundle.bundlePath);
+	}
+	
+	return xcodeBundle;
+}
+
+static void LoadXcodeFrameworks(NSBundle *xcodeBundle)
+{
+	NSURL *xcodeContentsURL = [[xcodeBundle privateFrameworksURL] URLByDeletingLastPathComponent];
+	
+	NSString *xcodeFrameworks = NSProcessInfo.processInfo.environment[@"XCPROJ_XCODE_FRAMEWORKS"];
+	NSArray *frameworks;
+	if (xcodeFrameworks)
+	{
+		frameworks = [xcodeFrameworks componentsSeparatedByString:@":"];
+	}
+	else
+	{
+		// Xcode 5 requires DVTFoundation, CSServiceClient, IDEFoundation and Xcode3Core
+		// Xcode 6 requires DVTFoundation, DVTSourceControl, IDEFoundation and Xcode3Core
+		// Xcode 7 requires DVTFoundation, DVTSourceControl, IBFoundation, IBAutolayoutFoundation, IDEFoundation and Xcode3Core
+		// Xcode 7.3 requires DVTFoundation, DVTSourceControl, DVTServices, DVTPortal, IBFoundation, IBAutolayoutFoundation, IDEFoundation and Xcode3Core
+		frameworks = @[ @"DVTFoundation.framework", @"DVTSourceControl.framework", @"DVTServices.framework", @"DVTPortal.framework", @"CSServiceClient.framework", @"IBFoundation.framework", @"IBAutolayoutFoundation.framework", @"IDEFoundation.framework", @"Xcode3Core.ideplugin" ];
+	}
+	
+	for (NSString *framework in frameworks)
+	{
+		BOOL loaded = NO;
+		NSArray *xcodeSubdirectories = [[NSFileManager defaultManager] contentsOfDirectoryAtURL:xcodeContentsURL includingPropertiesForKeys:nil options:0 error:NULL];
+		for (NSURL *frameworksDirectoryURL in xcodeSubdirectories)
+		{
+			NSURL *frameworkURL = [frameworksDirectoryURL URLByAppendingPathComponent:framework];
+			NSBundle *frameworkBundle = [NSBundle bundleWithURL:frameworkURL];
+			if (frameworkBundle)
+			{
+				NSError *loadError = nil;
+				loaded = [frameworkBundle loadAndReturnError:&loadError];
+				if (!loaded)
+				{
+					ddfprintf(stderr, @"The %@ %@ failed to load: %@\n", [framework stringByDeletingPathExtension], [framework pathExtension], loadError);
+					exit(EX_SOFTWARE);
+				}
+			}
+			
+			if (loaded)
+				break;
+		}
+	}
+}
+
+static void InitializeXcodeFrameworks(void)
+{
+	void(*IDEInitialize)(int initializationOptions, NSError **error) = dlsym(RTLD_DEFAULT, "IDEInitialize");
+	if (!IDEInitialize)
+	{
+		ddfprintf(stderr, @"IDEInitialize function not found.\n");
+		exit(EX_SOFTWARE);
+	}
+	
+	void(*XCInitializeCoreIfNeeded)(int initializationOptions) = dlsym(RTLD_DEFAULT, "XCInitializeCoreIfNeeded");
+	if (!XCInitializeCoreIfNeeded)
+	{
+		ddfprintf(stderr, @"XCInitializeCoreIfNeeded function not found.\n");
+		exit(EX_SOFTWARE);
+	}
+	
+	// Temporary redirect stderr to /dev/null in order not to print plugin loading errors
+	// Adapted from http://stackoverflow.com/questions/4832603/how-could-i-temporary-redirect-stdout-to-a-file-in-a-c-program/4832902#4832902
+	fflush(stderr);
+	int saved_stderr = dup(STDERR_FILENO);
+	int dev_null = open("/dev/null", O_WRONLY);
+	dup2(dev_null, STDERR_FILENO);
+	close(dev_null);
+	// Xcode3Core.ideplugin`-[Xcode3CommandLineBuildTool run] calls IDEInitialize(NSClassFromString(@"NSApplication") == nil, &error)
+	IDEInitialize(1, NULL);
+	// DevToolsCore`+[PBXProject projectWithFile:errorHandler:readOnly:] calls XCInitializeCoreIfNeeded(NSClassFromString(@"NSApplication") == nil)
+	XCInitializeCoreIfNeeded(0);
+	fflush(stderr);
+	dup2(saved_stderr, STDERR_FILENO);
+	close(saved_stderr);
+}
+
+static void WorkaroundRadar18512876(void)
+{
+	NSString *xmlPlist = @"<?xml version=\"1.0\" encoding=\"UTF-8\"?><plist version=\"1.0\"><string>&#x1F680;</string></plist>";
+	NSData *xmlPlistData = [xmlPlist dataUsingEncoding:NSUTF8StringEncoding];
+	BOOL shouldWorkaroundRadar18512876 = ![@"\U0001F680" isEqual:[NSPropertyListSerialization propertyListWithData:xmlPlistData options:0 format:NULL error:NULL]];
+	if (shouldWorkaroundRadar18512876)
+	{
+		Method plistWithDescriptionData = class_getClassMethod([NSDictionary class], @selector(plistWithDescriptionData:));
+		id (*plistWithDescriptionDataIMP)(id, SEL, NSData *) = (__typeof__(plistWithDescriptionDataIMP))method_getImplementation(plistWithDescriptionData);
+		method_setImplementation(plistWithDescriptionData, imp_implementationWithBlock(^(id _self, NSData *data) {
+			if (data.length >= 5 && [[data subdataWithRange:NSMakeRange(0, 5)] isEqualToData:[@"<?xml" dataUsingEncoding:NSASCIIStringEncoding]])
+				return [XMLPlistDecoder plistWithData:data];
+			else
+				return plistWithDescriptionDataIMP(_self, @selector(plistWithDescriptionData:), data);
+		}));
+	}
+}
+
+@implementation Xcproj (LoadFrameworks)
+
+Class PBXGroup = Nil;
+Class PBXProject = Nil;
+Class PBXReference = Nil;
+Class XCBuildConfiguration = Nil;
+Class IDEBuildParameters = Nil;
+
++ (void) setPBXGroup:(Class)class                  { PBXGroup = class; }
++ (void) setPBXProject:(Class)class                { PBXProject = class; }
++ (void) setPBXReference:(Class)class              { PBXReference = class; }
++ (void) setXCBuildConfiguration:(Class)class      { XCBuildConfiguration = class; }
++ (void) setIDEBuildParameters:(Class)class        { IDEBuildParameters = class; }
++ (void) setValue:(id)value forUndefinedKey:(NSString *)key { /* ignore */ }
+
++ (void) loadFrameworks
+{
+	static BOOL initialized = NO;
+	if (initialized)
+		return;
+	
+	LoadXcodeFrameworks(XcodeBundle());
+	InitializeXcodeFrameworks();
+	WorkaroundRadar18512876();
+	
+	BOOL isSafe = YES;
+	NSArray *protocols = @[@protocol(PBXBuildFile),
+	                       @protocol(PBXBuildPhase),
+	                       @protocol(PBXContainer),
+	                       @protocol(PBXFileReference),
+	                       @protocol(PBXGroup),
+	                       @protocol(PBXProject),
+	                       @protocol(PBXReference),
+	                       @protocol(PBXTarget),
+	                       @protocol(XCBuildConfiguration),
+	                       @protocol(XCConfigurationList),
+	                       @protocol(IDEBuildParameters)];
+	
+	for (Protocol *protocol in protocols)
+	{
+		NSError *classError = nil;
+		Class class = XCDClassFromProtocol(protocol, &classError);
+		if (class)
+			[self setValue:class forKey:[NSString stringWithCString:protocol_getName(protocol) encoding:NSUTF8StringEncoding]];
+		else
+		{
+			isSafe = NO;
+			ddfprintf(stderr, @"%@\n%@\n", [classError localizedDescription], [classError userInfo]);
+		}
+	}
+	
+	if (!isSafe)
+		exit(EX_SOFTWARE);
+	
+	initialized = YES;
+}
+
+@end

--- a/Sources/Xcproj+LoadFrameworks.m
+++ b/Sources/Xcproj+LoadFrameworks.m
@@ -10,7 +10,6 @@
 
 #import <dlfcn.h>
 #import <objc/runtime.h>
-#import "DDCommandLineInterface.h"
 #import "XCDUndocumentedChecker.h"
 #import "XMLPlistDecoder.h"
 
@@ -63,7 +62,8 @@ static NSBundle * LocateXcodeBundle(NSError **error)
 	
 	if (xcodeAppPath && ![[xcodeAppPath stringByResolvingSymlinksInPath] isEqualToString:xcodeBundle.bundlePath])
 	{
-		ddfprintf(stderr, @"WARNING: '%@' does not point to an Xcode app, using '%@'\n", xcodeAppPath, xcodeBundle.bundlePath);
+		NSString *warning = [NSString stringWithFormat:@"WARNING: '%@' does not point to an Xcode app, using '%@'", xcodeAppPath, xcodeBundle.bundlePath];
+		fprintf(stderr, "%s\n", warning.UTF8String);
 	}
 	
 	return xcodeBundle;

--- a/Sources/Xcproj.m
+++ b/Sources/Xcproj.m
@@ -97,8 +97,20 @@
 	BOOL loaded = [self.class loadFrameworks:&error];
 	if (!loaded)
 	{
-		ddfprintf(stderr, @"%@\n", error.localizedDescription);
-		exit(EX_CONFIG);
+		BOOL isXcprojError = [error.domain isEqualToString:XcprojErrorDomain];
+		if (!isXcprojError)
+		{
+			ddfprintf(stderr, @"An unknown error occurred: %@\n", error);
+			exit(EX_SOFTWARE);
+		}
+
+		switch ((XcprojError)error.code) {
+			case XcprojErrorXcodeBundleNotFound:
+			{
+				ddfprintf(stderr, @"%@\n", error.localizedDescription);
+				exit(EX_CONFIG);
+			}
+		}
 	}
 	
 	NSString *currentDirectoryPath = [[NSFileManager defaultManager] currentDirectoryPath];

--- a/Sources/Xcproj.m
+++ b/Sources/Xcproj.m
@@ -93,7 +93,6 @@
 		[self printUsage:EX_USAGE];
 	
 	NSError *error;
-
 	BOOL loaded = [self.class loadFrameworks:&error];
 	if (!loaded)
 	{
@@ -119,6 +118,11 @@
 			case XcprojErrorXCInitializeCoreIfNeededNotFound:
 			{
 				ddfprintf(stderr, @"%@\n", error.localizedDescription);
+				exit(EX_SOFTWARE);
+			}
+			case XcprojErrorClassLoadingFailed:
+			{
+				ddfprintf(stderr, @"%@: errors: %@\n", error.localizedDescription, [error.userInfo objectForKey:XcprojClassLoadErrorsKey]);
 				exit(EX_SOFTWARE);
 			}
 		}

--- a/Sources/Xcproj.m
+++ b/Sources/Xcproj.m
@@ -242,8 +242,6 @@ static void WorkaroundRadar18512876(void)
 
 - (void) setProject:(NSString *)projectName
 {
-	[self.class initializeXcproj];
-	
 	if (![PBXProject isProjectWrapperExtension:[projectName pathExtension]])
 		@throw [DDCliParseException parseExceptionWithReason:[NSString stringWithFormat:@"The project name %@ does not have a valid extension.", projectName] exitCode:EX_USAGE];
 	

--- a/Sources/Xcproj.m
+++ b/Sources/Xcproj.m
@@ -110,6 +110,11 @@
 				ddfprintf(stderr, @"%@\n", error.localizedDescription);
 				exit(EX_CONFIG);
 			}
+			case XcprojErrorFrameworksNotLoaded:
+			{
+				ddfprintf(stderr, @"%@: %@\n", error.localizedDescription, [error.userInfo objectForKey:NSUnderlyingErrorKey]);
+				exit(EX_SOFTWARE);
+			}
 		}
 	}
 	

--- a/Sources/Xcproj.m
+++ b/Sources/Xcproj.m
@@ -92,7 +92,14 @@
 	if ([arguments count] < 1)
 		[self printUsage:EX_USAGE];
 	
-	[self.class loadFrameworks];
+	NSError *error;
+
+	BOOL loaded = [self.class loadFrameworks:&error];
+	if (!loaded)
+	{
+		ddfprintf(stderr, @"%@\n", error.localizedDescription);
+		exit(EX_CONFIG);
+	}
 	
 	NSString *currentDirectoryPath = [[NSFileManager defaultManager] currentDirectoryPath];
 	

--- a/Sources/Xcproj.m
+++ b/Sources/Xcproj.m
@@ -115,6 +115,12 @@
 				ddfprintf(stderr, @"%@: %@\n", error.localizedDescription, [error.userInfo objectForKey:NSUnderlyingErrorKey]);
 				exit(EX_SOFTWARE);
 			}
+			case XcprojErrorIDEInitializeNotFound:
+			case XcprojErrorXCInitializeCoreIfNeededNotFound:
+			{
+				ddfprintf(stderr, @"%@\n", error.localizedDescription);
+				exit(EX_SOFTWARE);
+			}
 		}
 	}
 	

--- a/Sources/Xcproj.m
+++ b/Sources/Xcproj.m
@@ -7,11 +7,7 @@
 //
 
 #import "Xcproj.h"
-
-#import <dlfcn.h>
-#import <objc/runtime.h>
-#import "XCDUndocumentedChecker.h"
-#import "XMLPlistDecoder.h"
+#import "Xcproj+LoadFrameworks.h"
 
 @implementation Xcproj
 {
@@ -21,206 +17,6 @@
 	NSString *_configurationName;
 	
 	id<PBXTarget> _target;
-}
-
-static Class PBXGroup = Nil;
-static Class PBXProject = Nil;
-static Class PBXReference = Nil;
-static Class XCBuildConfiguration = Nil;
-static Class IDEBuildParameters = Nil;
-
-+ (void) setPBXGroup:(Class)class                  { PBXGroup = class; }
-+ (void) setPBXProject:(Class)class                { PBXProject = class; }
-+ (void) setPBXReference:(Class)class              { PBXReference = class; }
-+ (void) setXCBuildConfiguration:(Class)class      { XCBuildConfiguration = class; }
-+ (void) setIDEBuildParameters:(Class)class        { IDEBuildParameters = class; }
-+ (void) setValue:(id)value forUndefinedKey:(NSString *)key { /* ignore */ }
-
-static NSString *XcodeBundleIdentifier = @"com.apple.dt.Xcode";
-
-static NSBundle * XcodeBundleAtPath(NSString *path)
-{
-	NSBundle *xcodeBundle = [NSBundle bundleWithPath:path];
-	return [xcodeBundle.bundleIdentifier isEqualToString:XcodeBundleIdentifier] ? xcodeBundle : nil;
-}
-
-static NSBundle * XcodeBundle(void)
-{
-	NSString *xcodeAppPath = NSProcessInfo.processInfo.environment[@"XCPROJ_XCODE_APP_PATH"];
-	NSBundle *xcodeBundle = XcodeBundleAtPath(xcodeAppPath);
-	if (!xcodeBundle)
-	{
-		NSTask *task = [NSTask new];
-		task.launchPath = @"/usr/bin/xcode-select";
-		task.arguments = @[@"--print-path"];
-		task.standardOutput = [NSPipe new];
-
-		[task launch];
-		[task waitUntilExit];
-
-		if (task.terminationStatus == 0)
-		{
-			NSData *outputData = [[task.standardOutput fileHandleForReading] readDataToEndOfFile];
-			NSString *outputString = [[NSString alloc] initWithData:outputData encoding:NSUTF8StringEncoding];
-			NSString *xcodePath = [[outputString stringByDeletingLastPathComponent] stringByDeletingLastPathComponent];
-			xcodeBundle = XcodeBundleAtPath(xcodePath);
-		}
-	}
-
-	if (!xcodeBundle)
-	{
-		NSURL *xcodeURL = [[NSWorkspace sharedWorkspace] URLForApplicationWithBundleIdentifier:XcodeBundleIdentifier];
-		xcodeBundle = XcodeBundleAtPath(xcodeURL.path);
-	}
-	
-	if (!xcodeBundle)
-	{
-		ddfprintf(stderr, @"Xcode.app not found.\n");
-		exit(EX_CONFIG);
-	}
-	
-	if (xcodeAppPath && ![[xcodeAppPath stringByResolvingSymlinksInPath] isEqualToString:xcodeBundle.bundlePath])
-	{
-		ddfprintf(stderr, @"WARNING: '%@' does not point to an Xcode app, using '%@'\n", xcodeAppPath, xcodeBundle.bundlePath);
-	}
-	
-	return xcodeBundle;
-}
-
-static void LoadXcodeFrameworks(NSBundle *xcodeBundle)
-{
-	NSURL *xcodeContentsURL = [[xcodeBundle privateFrameworksURL] URLByDeletingLastPathComponent];
-	
-	NSString *xcodeFrameworks = NSProcessInfo.processInfo.environment[@"XCPROJ_XCODE_FRAMEWORKS"];
-	NSArray *frameworks;
-	if (xcodeFrameworks)
-	{
-		frameworks = [xcodeFrameworks componentsSeparatedByString:@":"];
-	}
-	else
-	{
-		// Xcode 5 requires DVTFoundation, CSServiceClient, IDEFoundation and Xcode3Core
-		// Xcode 6 requires DVTFoundation, DVTSourceControl, IDEFoundation and Xcode3Core
-		// Xcode 7 requires DVTFoundation, DVTSourceControl, IBFoundation, IBAutolayoutFoundation, IDEFoundation and Xcode3Core
-		// Xcode 7.3 requires DVTFoundation, DVTSourceControl, DVTServices, DVTPortal, IBFoundation, IBAutolayoutFoundation, IDEFoundation and Xcode3Core
-		frameworks = @[ @"DVTFoundation.framework", @"DVTSourceControl.framework", @"DVTServices.framework", @"DVTPortal.framework", @"CSServiceClient.framework", @"IBFoundation.framework", @"IBAutolayoutFoundation.framework", @"IDEFoundation.framework", @"Xcode3Core.ideplugin" ];
-	}
-	
-	for (NSString *framework in frameworks)
-	{
-		BOOL loaded = NO;
-		NSArray *xcodeSubdirectories = [[NSFileManager defaultManager] contentsOfDirectoryAtURL:xcodeContentsURL includingPropertiesForKeys:nil options:0 error:NULL];
-		for (NSURL *frameworksDirectoryURL in xcodeSubdirectories)
-		{
-			NSURL *frameworkURL = [frameworksDirectoryURL URLByAppendingPathComponent:framework];
-			NSBundle *frameworkBundle = [NSBundle bundleWithURL:frameworkURL];
-			if (frameworkBundle)
-			{
-				NSError *loadError = nil;
-				loaded = [frameworkBundle loadAndReturnError:&loadError];
-				if (!loaded)
-				{
-					ddfprintf(stderr, @"The %@ %@ failed to load: %@\n", [framework stringByDeletingPathExtension], [framework pathExtension], loadError);
-					exit(EX_SOFTWARE);
-				}
-			}
-			
-			if (loaded)
-				break;
-		}
-	}
-}
-
-static void InitializeXcodeFrameworks(void)
-{
-	void(*IDEInitialize)(int initializationOptions, NSError **error) = dlsym(RTLD_DEFAULT, "IDEInitialize");
-	if (!IDEInitialize)
-	{
-		ddfprintf(stderr, @"IDEInitialize function not found.\n");
-		exit(EX_SOFTWARE);
-	}
-	
-	void(*XCInitializeCoreIfNeeded)(int initializationOptions) = dlsym(RTLD_DEFAULT, "XCInitializeCoreIfNeeded");
-	if (!XCInitializeCoreIfNeeded)
-	{
-		ddfprintf(stderr, @"XCInitializeCoreIfNeeded function not found.\n");
-		exit(EX_SOFTWARE);
-	}
-	
-	// Temporary redirect stderr to /dev/null in order not to print plugin loading errors
-	// Adapted from http://stackoverflow.com/questions/4832603/how-could-i-temporary-redirect-stdout-to-a-file-in-a-c-program/4832902#4832902
-	fflush(stderr);
-	int saved_stderr = dup(STDERR_FILENO);
-	int dev_null = open("/dev/null", O_WRONLY);
-	dup2(dev_null, STDERR_FILENO);
-	close(dev_null);
-	// Xcode3Core.ideplugin`-[Xcode3CommandLineBuildTool run] calls IDEInitialize(NSClassFromString(@"NSApplication") == nil, &error)
-	IDEInitialize(1, NULL);
-	// DevToolsCore`+[PBXProject projectWithFile:errorHandler:readOnly:] calls XCInitializeCoreIfNeeded(NSClassFromString(@"NSApplication") == nil)
-	XCInitializeCoreIfNeeded(0);
-	fflush(stderr);
-	dup2(saved_stderr, STDERR_FILENO);
-	close(saved_stderr);
-}
-
-static void WorkaroundRadar18512876(void)
-{
-	NSString *xmlPlist = @"<?xml version=\"1.0\" encoding=\"UTF-8\"?><plist version=\"1.0\"><string>&#x1F680;</string></plist>";
-	NSData *xmlPlistData = [xmlPlist dataUsingEncoding:NSUTF8StringEncoding];
-	BOOL shouldWorkaroundRadar18512876 = ![@"\U0001F680" isEqual:[NSPropertyListSerialization propertyListWithData:xmlPlistData options:0 format:NULL error:NULL]];
-	if (shouldWorkaroundRadar18512876)
-	{
-		Method plistWithDescriptionData = class_getClassMethod([NSDictionary class], @selector(plistWithDescriptionData:));
-		id (*plistWithDescriptionDataIMP)(id, SEL, NSData *) = (__typeof__(plistWithDescriptionDataIMP))method_getImplementation(plistWithDescriptionData);
-		method_setImplementation(plistWithDescriptionData, imp_implementationWithBlock(^(id _self, NSData *data) {
-			if (data.length >= 5 && [[data subdataWithRange:NSMakeRange(0, 5)] isEqualToData:[@"<?xml" dataUsingEncoding:NSASCIIStringEncoding]])
-				return [XMLPlistDecoder plistWithData:data];
-			else
-				return plistWithDescriptionDataIMP(_self, @selector(plistWithDescriptionData:), data);
-		}));
-	}
-}
-
-+ (void) initializeXcproj
-{
-	static BOOL initialized = NO;
-	if (initialized)
-		return;
-	
-	LoadXcodeFrameworks(XcodeBundle());
-	InitializeXcodeFrameworks();
-	WorkaroundRadar18512876();
-	
-	BOOL isSafe = YES;
-	NSArray *protocols = @[@protocol(PBXBuildFile),
-	                       @protocol(PBXBuildPhase),
-	                       @protocol(PBXContainer),
-	                       @protocol(PBXFileReference),
-	                       @protocol(PBXGroup),
-	                       @protocol(PBXProject),
-	                       @protocol(PBXReference),
-	                       @protocol(PBXTarget),
-	                       @protocol(XCBuildConfiguration),
-	                       @protocol(XCConfigurationList),
-	                       @protocol(IDEBuildParameters)];
-	
-	for (Protocol *protocol in protocols)
-	{
-		NSError *classError = nil;
-		Class class = XCDClassFromProtocol(protocol, &classError);
-		if (class)
-			[self setValue:class forKey:[NSString stringWithCString:protocol_getName(protocol) encoding:NSUTF8StringEncoding]];
-		else
-		{
-			isSafe = NO;
-			ddfprintf(stderr, @"%@\n%@\n", [classError localizedDescription], [classError userInfo]);
-		}
-	}
-	
-	if (!isSafe)
-		exit(EX_SOFTWARE);
-	
-	initialized = YES;
 }
 
 // MARK: - Options
@@ -296,7 +92,7 @@ static void WorkaroundRadar18512876(void)
 	if ([arguments count] < 1)
 		[self printUsage:EX_USAGE];
 	
-	[self.class initializeXcproj];
+	[self.class loadFrameworks];
 	
 	NSString *currentDirectoryPath = [[NSFileManager defaultManager] currentDirectoryPath];
 	

--- a/xcproj.xcodeproj/project.pbxproj
+++ b/xcproj.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4A33ADEF1C768EC900AA5AD2 /* Xcproj+LoadFrameworks.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A33ADEE1C768EC900AA5AD2 /* Xcproj+LoadFrameworks.m */; };
 		8DD76F9A0486AA7600D96B5E /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7796FE84155DC02AAC07 /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8DD76F9C0486AA7600D96B5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08FB779EFE84155DC02AAC07 /* Foundation.framework */; };
 		C215308619DBE040002524A7 /* XMLPlistDecoder.m in Sources */ = {isa = PBXBuildFile; fileRef = C215308519DBE040002524A7 /* XMLPlistDecoder.m */; };
@@ -24,6 +25,8 @@
 		08FB7796FE84155DC02AAC07 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Sources/main.m; sourceTree = "<group>"; };
 		08FB779EFE84155DC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		32A70AAB03705E1F00C91783 /* xcproj_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = xcproj_Prefix.pch; path = Sources/xcproj_Prefix.pch; sourceTree = "<group>"; };
+		4A33ADED1C768EC900AA5AD2 /* Xcproj+LoadFrameworks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Xcproj+LoadFrameworks.h"; path = "Sources/Xcproj+LoadFrameworks.h"; sourceTree = "<group>"; };
+		4A33ADEE1C768EC900AA5AD2 /* Xcproj+LoadFrameworks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Xcproj+LoadFrameworks.m"; path = "Sources/Xcproj+LoadFrameworks.m"; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* xcproj */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = xcproj; sourceTree = BUILT_PRODUCTS_DIR; };
 		C20F5C151A92A57A004ADE6B /* IDEBuildParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IDEBuildParameters.h; sourceTree = "<group>"; };
 		C20F5C161A92A5F4004ADE6B /* IDEFoundation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IDEFoundation.h; sourceTree = "<group>"; };
@@ -94,6 +97,8 @@
 				08FB7796FE84155DC02AAC07 /* main.m */,
 				DA1DC00F10E59AED005A103B /* Xcproj.h */,
 				DA1DC00E10E59AED005A103B /* Xcproj.m */,
+				4A33ADED1C768EC900AA5AD2 /* Xcproj+LoadFrameworks.h */,
+				4A33ADEE1C768EC900AA5AD2 /* Xcproj+LoadFrameworks.m */,
 				DAFF25CA1303ECB100584E0E /* XCDUndocumentedChecker.h */,
 				DAFF25CB1303ECB100584E0E /* XCDUndocumentedChecker.m */,
 				C215308419DBE040002524A7 /* XMLPlistDecoder.h */,
@@ -234,6 +239,7 @@
 				C269E99117B3DCCC0099A0C5 /* DDGetoptLongParser.m in Sources */,
 				DAFF25CC1303ECB100584E0E /* XCDUndocumentedChecker.m in Sources */,
 				C269E98F17B3DCCC0099A0C5 /* DDCliParseException.m in Sources */,
+				4A33ADEF1C768EC900AA5AD2 /* Xcproj+LoadFrameworks.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
- Move framework loading code to a new `Xcproj+LoadFrameworks` category
- Replace calls to `ddprintf` and `exit` with `NSError`-based error handling.

Best reviewed commit-by-commit because of the large amount of code moved to a new file.
